### PR TITLE
Fix OkHttpBrowser.execute success check

### DIFF
--- a/src/main/java/webGrude/OkHttpBrowser.java
+++ b/src/main/java/webGrude/OkHttpBrowser.java
@@ -99,7 +99,7 @@ public class OkHttpBrowser implements LinkVisitor {
      */
     public <T> T execute(Request request, final Class<T> pageClass) throws IOException {
         try (Response response = client().newCall(request).execute()) {
-            if (response.isSuccessful()) {
+            if (!response.isSuccessful()) {
                 throw new IOException("Unsuccessful response " + response.code());
             }
             if (response.body() == null) {

--- a/src/test/java/webGrude/BrowserTest.java
+++ b/src/test/java/webGrude/BrowserTest.java
@@ -3,6 +3,7 @@ package webGrude;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.Request;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,5 +50,17 @@ public class BrowserTest {
 
         assertEquals("GET", recordedRequest.getMethod());
         assertEquals("/x/bar/y/baz", recordedRequest.getPath());
+    }
+
+    @Test
+    public void testExecute() throws IOException {
+        String url = mockWebServer.url("/foo").toString();
+        okhttp3.Request request = new okhttp3.Request.Builder()
+                .url(url)
+                .build();
+
+        Foo foo = okHttpBrowser.execute(request, Foo.class);
+
+        assertEquals("Title", foo.someContent.title);
     }
 }


### PR DESCRIPTION
## Summary
- handle successful responses in `OkHttpBrowser.execute`
- verify behaviour with `testExecute` unit test

## Testing
- `mvn -q -e -DskipTests=false test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840037195b88329b260792ee9293b6f